### PR TITLE
feat: adicionando hyperlinks do HATEOAS

### DIFF
--- a/src/main/java/com/film/catalog/film/entidade/Filme.java
+++ b/src/main/java/com/film/catalog/film/entidade/Filme.java
@@ -1,5 +1,7 @@
 package com.film.catalog.film.entidade;
 
+import org.springframework.hateoas.RepresentationModel;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,7 +18,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Filme {
+public class Filme extends RepresentationModel<Filme> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/film/catalog/film/service/FilmeService.java
+++ b/src/main/java/com/film/catalog/film/service/FilmeService.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -24,7 +26,8 @@ public class FilmeService {
     public ResponseEntity<List<Filme>> findAll() {
         List<Filme> filmeList = filmeRepository.findAll();
         for (Filme filme : filmeList) {
-            filme.add(linkTo(methodOn(FilmeController.class).findById(filme.getId())).withSelfRel());
+            Link uriFindCatalogoFilmeId = WebMvcLinkBuilder.linkTo(methodOn(FilmeController.class).findById(filme.getId())).withSelfRel();
+            filme.add(uriFindCatalogoFilmeId);
         }
         return ResponseEntity.status(HttpStatus.OK).body(filmeList);
     }
@@ -32,7 +35,8 @@ public class FilmeService {
     public ResponseEntity<Filme> findById(Long id) {
         Optional<Filme> filme = filmeRepository.findById(id);
         if (filme.isPresent()) {
-            filme.get().add(linkTo(methodOn(FilmeController.class).findAll()).withRel("Lista de filmes disponiveis"));
+            Link uri_catalogo_filmes = WebMvcLinkBuilder.linkTo(methodOn(FilmeController.class).findAll()).withRel("Lista de filmes disponiveis");
+            filme.get().add(uri_catalogo_filmes);
             return ResponseEntity.ok().body(filme.get());
         }
         return ResponseEntity.notFound().build();

--- a/src/main/java/com/film/catalog/film/service/FilmeService.java
+++ b/src/main/java/com/film/catalog/film/service/FilmeService.java
@@ -9,9 +9,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import com.film.catalog.film.controller.FilmeController;
 import com.film.catalog.film.dto.FilmeDto;
 import com.film.catalog.film.entidade.Filme;
 import com.film.catalog.film.repository.FilmeRepository;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
 @Service
 public class FilmeService {
@@ -20,12 +22,17 @@ public class FilmeService {
     private FilmeRepository filmeRepository;
 
     public ResponseEntity<List<Filme>> findAll() {
-        return ResponseEntity.ok().body(filmeRepository.findAll());
+        List<Filme> filmeList = filmeRepository.findAll();
+        for (Filme filme : filmeList) {
+            filme.add(linkTo(methodOn(FilmeController.class).findById(filme.getId())).withSelfRel());
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(filmeList);
     }
 
     public ResponseEntity<Filme> findById(Long id) {
         Optional<Filme> filme = filmeRepository.findById(id);
         if (filme.isPresent()) {
+            filme.get().add(linkTo(methodOn(FilmeController.class).findAll()).withRel("Lista de filmes disponiveis"));
             return ResponseEntity.ok().body(filme.get());
         }
         return ResponseEntity.notFound().build();


### PR DESCRIPTION
## Implementação de HATEOAS no serviço de filmes

**O que foi feito:**

* Implementados hyperlinks utilizando HATEOAS nas respostas dos endpoints do serviço de filmes.
* Adicionado link para obter os detalhes de um filme específico na listagem de filmes (`findAll`).
* Adicionado link para a listagem completa de filmes nos detalhes de um filme específico (`findById`).

**Motivação:**

* Facilitar a navegação entre os recursos disponíveis na API, seguindo o padrão HATEOAS, que promove a descoberta de recursos de maneira mais intuitiva e padronizada.

**Alterações detalhadas:**

* Na função `findAll`, para cada filme da lista, foi adicionado um link com `selfRel` para obter os detalhes do filme.
* Na função `findById`, foi adicionado um link com a relação "Lista de filmes disponíveis" para retornar à listagem completa de filmes.

**Impacto:**

* Melhoria na usabilidade da API para os clientes, permitindo uma navegação mais eficiente entre os recursos.
